### PR TITLE
The anchor has been changed

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -30,7 +30,7 @@ const a = 1
 ```
 
 `let` is the new `var`. Constants work just like `let`, but can't be reassigned.
-See: [Let and const](http://babeljs.io/docs/learn-es2015/#let-const)
+See: [Let and const](http://babeljs.io/learn-es2015/#ecmascript-2015-features-let-const)
 
 ### Backtick strings
 
@@ -50,7 +50,7 @@ world
 ```
 
 Templates and multiline strings.
-See: [Template strings](http://babeljs.io/docs/learn-es2015/#template-strings)
+See: [Template strings](http://babeljs.io/learn-es2015/#ecmascript-2015-features-template-strings)
 
 ### Binary and octal literals
 
@@ -59,7 +59,7 @@ let bin = 0b1010010
 let oct = 0o755
 ```
 
-See: [Binary and octal literals](http://babeljs.io/docs/learn-es2015/#binary-and-octal-literals)
+See: [Binary and octal literals](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-binary-and-octal-literals)
 
 ### New methods
 
@@ -71,7 +71,7 @@ See: [Binary and octal literals](http://babeljs.io/docs/learn-es2015/#binary-and
 "\u1E9B\u0323".normalize("NFC")
 ```
 
-See: [New methods](http://babeljs.io/docs/learn-es2015/#math-number-string-object-apis)
+See: [New methods](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-math-number-string-object-apis)
 
 ### Classes
 
@@ -117,7 +117,7 @@ class Circle extends Shape {
 {: data-line="1"}
 
 Syntactic sugar for prototypes.
-See: [Classes](http://babeljs.io/docs/learn-es2015/#classes)
+See: [Classes](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-classes)
 
 ### Exponent operator
 
@@ -142,7 +142,7 @@ new Promise((resolve, reject) => {
 {: data-line="1"}
 
 For asynchronous programming.
-See: [Promises](http://babeljs.io/docs/learn-es2015/#promises)
+See: [Promises](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-promises)
 
 ### Using promises
 
@@ -200,7 +200,7 @@ let {title, author} = {
 {: data-line="1"}
 
 Supports for matching arrays and objects.
-See: [Destructuring](http://babeljs.io/docs/learn-es2015/#destructuring)
+See: [Destructuring](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-destructuring)
 
 
 ### Function arguments
@@ -312,7 +312,7 @@ fn(...[1, 2, 3])
 {: data-line="1"}
 
 Default, rest, spread.
-See: [Function arguments](http://babeljs.io/docs/learn-es2015/#default-rest-spread)
+See: [Function arguments](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-default-rest-spread)
 
 ### Fat arrows
 
@@ -343,7 +343,7 @@ numbers.map(n => n * 2)
 {: data-line="1"}
 
 Like functions but with `this` preserved.
-See: [Fat arrows](http://babeljs.io/docs/learn-es2015/#arrows)
+See: [Fat arrows](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-arrows)
 
 Objects
 -------
@@ -355,7 +355,7 @@ module.exports = { hello, bye }
 // Same as: module.exports = { hello: hello, bye: bye }
 ```
 
-See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals)
+See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-enhanced-object-literals)
 
 ### Methods
 
@@ -369,7 +369,7 @@ const App = {
 ```
 {: data-line="2"}
 
-See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals)
+See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-enhanced-object-literals)
 
 ### Getters and setters
 
@@ -385,7 +385,7 @@ const App = {
 ```
 {: data-line="2,5"}
 
-See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals)
+See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-enhanced-object-literals)
 
 ### Computed property names
 
@@ -398,7 +398,7 @@ let handlers = {
 ```
 {: data-line="3"}
 
-See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals)
+See: [Object literal enhancements](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-enhanced-object-literals)
 
 Modules
 -------
@@ -431,7 +431,7 @@ import { indentSpaces as indent } from 'helpers'
 ```
 
 `import` is the new `require()`.
-See: [Module imports](http://babeljs.io/docs/learn-es2015/#modules)
+See: [Module imports](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-modules)
 
 ### Exports
 
@@ -451,7 +451,7 @@ export const pi = 3.14159
 ```
 
 `export` is the new `module.exports`.
-See: [Module exports](http://babeljs.io/docs/learn-es2015/#modules)
+See: [Module exports](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-modules)
 
 Generators
 ----------
@@ -473,7 +473,7 @@ gen.next().value  // → 2
 ```
 
 It's complicated.
-See: [Generators](http://babeljs.io/docs/learn-es2015/#generators)
+See: [Generators](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-generators)
 
 ### For..of iteration
 
@@ -484,4 +484,4 @@ for (let i of iterable) {
 ```
 
 For iterating through generators and arrays.
-See: [For..of iteration](http://babeljs.io/docs/learn-es2015/#iterators-for-of)
+See: [For..of iteration](http://babeljs.io/docs/learn-es2015/#ecmascript-2015-features-iterators-for-of)


### PR DESCRIPTION
There is a major changes in babeljs.io's docs, the anchors in learn-es2015 now start with `#ecmascript-2015-features-` then the pointed anchor name and became like this `#ecmascript-2015-features-generators.`